### PR TITLE
feat: Add help targets for mage

### DIFF
--- a/mage/help/doc.go
+++ b/mage/help/doc.go
@@ -4,5 +4,5 @@
 // is optional during mage import.
 //
 // The only limitation of this package is that it can only be imported once in a magefile and it should be under the
-// help namespace(eg // mage:import help).
+// help namespace (eg `//mage:import help`).
 package help

--- a/mage/help/doc.go
+++ b/mage/help/doc.go
@@ -1,0 +1,8 @@
+// Package help provides a help command for mage targets defines in mesosphere/daggers repository.
+//
+// The purpose of the dedicated package is to avoid name conflicts between different mage targets since namespaces
+// is optional during mage import.
+//
+// The only limitation of this package is that it can only be imported once in a magefile and it should be under the
+// help namespace(eg // mage:import help).
+package help

--- a/mage/help/help.go
+++ b/mage/help/help.go
@@ -4,16 +4,15 @@ import "fmt"
 
 // Precommit shows the help for precommit.
 func Precommit() {
-	fmt.Print(`Usage: mage <namespace:>precommit (e.g. mage lint:precommit or mage precommit)
+	fmt.Println(`Usage: mage <namespace:>precommit (e.g. mage lint:precommit or mage precommit)
 
-Environment variables:
-	PRECOMMIT_BASE_IMAGE:    The base image to run pre-commit in.
-`)
+Configurable via the following environment variables:
+	PRECOMMIT_BASE_IMAGE:    The base image to run pre-commit in.`)
 }
 
 // Svu shows the help for svu.
 func Svu() {
-	fmt.Print(`Usage: mage <namespace:><command> (e.g. mage svu:current or mage next)
+	fmt.Println(`Usage: mage <namespace:><command> (e.g. mage svu:current or mage next)
 
 Commands:
 	current:  Print the current version.
@@ -22,7 +21,7 @@ Commands:
 	minor:    Print the next minor version.
 	patch:    Print the next patch version.
 
-Environment variables:
+Configurable via the following environment variables:
 	SVU_VERSION:    SVUVersion specifies the version of svu to use.
 	SVU_METADATA:   Controls whether to include pre-release and build metadata in the version. Defaults to true.
 	SVU_PATTERN:    Sets the pattern to use when searching for tags. Defaults to "*".
@@ -30,6 +29,5 @@ Environment variables:
 	SVU_BUILD:      Controls whether to include build metadata in the version. Defaults to true.
 	SVU_PREFIX:     Sets the prefix to use when searching for tags. Defaults to "v".
 	SVU_SUFFIX:     Sets the suffix to use when searching for tags. Defaults to "".
-	SVU_TAG_MODE:   Sets the tag mode to use when searching for tags. Defaults to "all-branches".
-`)
+	SVU_TAG_MODE:   Sets the tag mode to use when searching for tags. Defaults to "all-branches".`)
 }

--- a/mage/help/help.go
+++ b/mage/help/help.go
@@ -1,0 +1,35 @@
+package help
+
+import "fmt"
+
+// Precommit shows the help for precommit.
+func Precommit() {
+	fmt.Print(`Usage: mage <namespace:>precommit (e.g. mage lint:precommit or mage precommit)
+
+Environment variables:
+	PRECOMMIT_BASE_IMAGE:    The base image to run pre-commit in.
+`)
+}
+
+// Svu shows the help for svu.
+func Svu() {
+	fmt.Print(`Usage: mage <namespace:><command> (e.g. mage svu:current or mage next)
+
+Commands:
+	current:  Print the current version.
+	next:     Print the next version.
+	major:    Print the next major version.
+	minor:    Print the next minor version.
+	patch:    Print the next patch version.
+
+Environment variables:
+	SVU_VERSION:    SVUVersion specifies the version of svu to use.
+	SVU_METADATA:   Controls whether to include pre-release and build metadata in the version. Defaults to true.
+	SVU_PATTERN:    Sets the pattern to use when searching for tags. Defaults to "*".
+	SVU_PRERELEASE: Controls whether to include pre-release metadata in the version. Defaults to true.
+	SVU_BUILD:      Controls whether to include build metadata in the version. Defaults to true.
+	SVU_PREFIX:     Sets the prefix to use when searching for tags. Defaults to "v".
+	SVU_SUFFIX:     Sets the suffix to use when searching for tags. Defaults to "".
+	SVU_TAG_MODE:   Sets the tag mode to use when searching for tags. Defaults to "all-branches".
+`)
+}

--- a/mage/precommit/mage.go
+++ b/mage/precommit/mage.go
@@ -15,7 +15,7 @@ const (
 	baseImageEnvVar = "PRECOMMIT_BASE_IMAGE"
 )
 
-// Precommit runs all the precommit checks.
+// Precommit runs all the precommit checks. Run `mage help:precommit` for information on available options.
 func Precommit(ctx context.Context) error {
 	return PrecommitWithOptions(ctx)
 }

--- a/mage/precommit/mage.go
+++ b/mage/precommit/mage.go
@@ -16,9 +16,6 @@ const (
 )
 
 // Precommit runs all the precommit checks.
-// Configurable via the following environment variables:
-//
-//	PRECOMMIT_BASE_IMAGE - The base image to run pre-commit in.
 func Precommit(ctx context.Context) error {
 	return PrecommitWithOptions(ctx)
 }


### PR DESCRIPTION
Adds target for help commands for existing targets. 

Import for target:

```

//go:build mage

package main

import (
	// mage:import svu
	_ "github.com/mesosphere/daggers/mage/svu"

	// mage:import lint
	_ "github.com/mesosphere/daggers/mage/precommit"

	// mage:import help
	_ "github.com/mesosphere/daggers/mage/help"
)
```

Help text:
 
```
› mage
Targets:
  help:precommit    shows the help for precommit.
  help:svu          shows the help for svu.
  lint:precommit    runs all the precommit checks.
  svu:current       runs svu current.
  svu:major         runs svu major.
  svu:minor         runs svu minor.
  svu:next          runs svu next.
  svu:patch         runs svu patch.

› mage help:precommit
Usage: mage <namespace:>precommit (e.g. mage lint:precommit or mage precommit)

Environment variables:
        PRECOMMIT_BASE_IMAGE:    The base image to run pre-commit in.

in daggers/ on aweris/add-help-targets 
› mage help:svu      
Usage: mage <namespace:><command> (e.g. mage svu:current or mage next)

Commands:
        current:  Print the current version.
        next:     Print the next version.
        major:    Print the next major version.
        minor:    Print the next minor version.
        patch:    Print the next patch version.

Environment variables:
        SVU_VERSION:    SVUVersion specifies the version of svu to use.
        SVU_METADATA:   Controls whether to include pre-release and build metadata in the version. Defaults to true.
        SVU_PATTERN:    Sets the pattern to use when searching for tags. Defaults to "*".
        SVU_PRERELEASE: Controls whether to include pre-release metadata in the version. Defaults to true.
        SVU_BUILD:      Controls whether to include build metadata in the version. Defaults to true.
        SVU_PREFIX:     Sets the prefix to use when searching for tags. Defaults to "v".
        SVU_SUFFIX:     Sets the suffix to use when searching for tags. Defaults to "".
        SVU_TAG_MODE:   Sets the tag mode to use when searching for tags. Defaults to "all-branches".
```

Depends on #18 