### PR TITLE
fix: Print command output if mage is not running in verbose mode

### DIFF
--- a/mage/precommit/mage.go
+++ b/mage/precommit/mage.go
@@ -2,6 +2,7 @@ package precommit
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"dagger.io/dagger"
@@ -43,5 +44,17 @@ func PrecommitWithOptions(ctx context.Context, opts ...precommitdagger.Option) e
 		opts = append([]precommitdagger.Option{precommitdagger.BaseImage(baseImage)}, opts...)
 	}
 
-	return precommitdagger.Run(ctx, client, client.Host().Workdir().Read(), opts...)
+	cmdOut, err := precommitdagger.Run(ctx, client, client.Host().Workdir().Read(), opts...)
+
+	// When verbose flag is false, the output is not printed to the console, only redirected to the log file.
+	// To work around this, we print the output to the console if the verbose flag is not set.
+	if !verbose {
+		fmt.Println(cmdOut)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
Default log output for precommit:

```
› mage lint:precommit
Trim Trailing Whitespace.................................................Passed
Mixed line ending........................................................Passed
Don't commit to branch...................................................Passed
Check for added large files..............................................Passed
Check for case conflicts.................................................Passed
Check for merge conflicts................................................Passed
Check that executables have shebangs.................(no files to check)Skipped
Check for broken symlinks............................(no files to check)Skipped
Fix End of Files.........................................................Passed
Non-executable shell script filename ends in .sh.....(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
```