### PR TITLE
feat: Add asdf mage targets

### DIFF
--- a/mage/asdf/asdf.go
+++ b/mage/asdf/asdf.go
@@ -1,0 +1,119 @@
+package asdf
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/magefile/mage/sh"
+)
+
+// Plugins is a simple custom type to hold plugin name to quickly check if a plugin is already added.
+type Plugins map[string]bool
+
+// Version is a simple struct to holds plugin version information.
+type Version struct {
+	// Plugin version
+	Version string
+
+	// If true, plugin version should be ignored during upgrade
+	VersionFreeze bool
+}
+
+// PluginVersions is a map of plugin name and version.
+type PluginVersions map[string]Version
+
+// ListPlugins lists all plugins installed in asdf.
+func ListPlugins() (Plugins, error) {
+	plugins := make(Plugins)
+
+	// List all plugins
+	output, err := sh.Output("asdf", "plugin", "list")
+	if err != nil {
+		return nil, err
+	}
+
+	plugin := bufio.NewScanner(strings.NewReader(output))
+
+	for plugin.Scan() {
+		plugins[strings.TrimSpace(plugin.Text())] = true
+	}
+
+	return plugins, nil
+}
+
+// ListPluginVersions lists all installed versions of software for the specified plugin in ascending order.
+func ListPluginVersions(plugin string) ([]string, error) {
+	output, err := sh.Output("asdf", "list", plugin)
+	if err != nil {
+		return nil, err
+	}
+
+	versions := make([]string, 0)
+
+	scanner := bufio.NewScanner(strings.NewReader(output))
+
+	for scanner.Scan() {
+		versions = append(versions, strings.TrimSpace(scanner.Text()))
+	}
+
+	return versions, nil
+}
+
+// ParseToolVersions parses .tool-versions file and returns a map of plugin name and version.
+func ParseToolVersions() (PluginVersions, error) {
+	plugins := make(PluginVersions)
+
+	// Check if .tool-versions file exists, if not, return empty map
+	if _, err := os.Stat(".tool-versions"); os.IsNotExist(err) {
+		fmt.Println("no .tool-versions file found in current directory, skipping")
+		return plugins, nil
+	}
+
+	tools, err := os.Open(".tool-versions")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read .tools-versions: %w", err)
+	}
+
+	traverseNonCommentLines(tools, func(line string) {
+		// Split the line into tokens. Normally, token array should have 2 elements. However, this file can have
+		// comments which are prefixed with a #. We're using these comments to freeze versions of plugins.
+		// If a plugin is frozen,
+		// we'll not try to upgrade it.
+		tokens := strings.Split(line, " ")
+
+		version := Version{
+			Version:       tokens[1],
+			VersionFreeze: false,
+		}
+
+		// If next two tokens are # and FREEZE, then we'll freeze the version of the plugin
+		if len(tokens) > 3 {
+			version.VersionFreeze = tokens[2] == "#" && tokens[3] == "FREEZE"
+		}
+
+		plugins[tokens[0]] = version
+	})
+
+	return plugins, nil
+}
+
+func traverseNonCommentLines(r io.Reader, visit func(line string)) {
+	scanner := bufio.NewScanner(r)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Trim whitespace
+		line = strings.TrimSpace(line)
+
+		// Skip comments and empty lines
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		visit(line)
+	}
+}

--- a/mage/asdf/doc.go
+++ b/mage/asdf/doc.go
@@ -1,0 +1,2 @@
+// Package asdf provides a simple interface to the asdf version manager.
+package asdf

--- a/mage/asdf/mage.go
+++ b/mage/asdf/mage.go
@@ -1,0 +1,138 @@
+package asdf
+
+import (
+	"fmt"
+
+	"github.com/magefile/mage/sh"
+)
+
+// Install installs all plugins and versions specified in local and global .tool-versions file.
+func Install() error {
+	plugins, err := ListPlugins()
+	if err != nil {
+		return err
+	}
+
+	tools, err := ParseToolVersions()
+	if err != nil {
+		return err
+	}
+
+	for plugin := range tools {
+		ensurePluginExist(plugins, plugin)
+	}
+
+	// Install all plugins and versions
+	return sh.RunV("asdf", "install")
+}
+
+// InstallPlugins installs given plugins and version specified in local .tool-versions file or latest version
+// if not specified.
+func InstallPlugins(pluginsToInstall ...string) error {
+	plugins, err := ListPlugins()
+	if err != nil {
+		return err
+	}
+
+	tools, err := ParseToolVersions()
+	if err != nil {
+		return err
+	}
+
+	for _, plugin := range pluginsToInstall {
+		version, ok := tools[plugin]
+		if !ok {
+			return fmt.Errorf("plugin %s is not specified in .tool-versions", plugin)
+		}
+
+		ensurePluginExist(plugins, plugin)
+
+		err = installPackage(plugin, version)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Upgrade upgrades all plugins and versions specified in local .tool-versions file.
+//
+//nolint:revive // Disable cognitive-complexity check. There is not enough gain from reducing cognitive-complexity,
+func Upgrade() error {
+	plugins, err := ListPlugins()
+	if err != nil {
+		return err
+	}
+
+	tools, err := ParseToolVersions()
+	if err != nil {
+		return err
+	}
+
+	for plugin, version := range tools {
+		ensurePluginExist(plugins, plugin)
+
+		// If plugin is frozen, we'll not upgrade it
+		if version.VersionFreeze {
+			fmt.Printf("plugin %s is frozen, with version %s, skipping upgrade\n", plugin, version.Version)
+			continue
+		}
+
+		latest, err := getLatestVersion(plugin)
+		if err != nil {
+			return err
+		}
+
+		// if latest version is the same as the one specified in .tool-versions, no need to do anything
+		if latest == version.Version {
+			fmt.Printf("plugin %s is already up to date with version %s\n", plugin, version.Version)
+
+			continue
+		}
+
+		fmt.Printf("upgrading %s from %s to %s\n", plugin, version.Version, latest)
+
+		err = sh.RunV("asdf", "install", plugin, latest)
+		if err != nil {
+			return fmt.Errorf("failed to upgrade %s: %w", plugin, err)
+		}
+
+		err = sh.RunV("asdf", "local", plugin, latest)
+		if err != nil {
+			return fmt.Errorf("failed to set %s to %s: %w", plugin, latest, err)
+		}
+	}
+
+	return nil
+}
+
+func getLatestVersion(plugin string) (string, error) {
+	allVersions, err := ListPluginVersions(plugin)
+	if err != nil {
+		return "", fmt.Errorf("failed to list versions for plugin %s: %w", plugin, err)
+	}
+
+	// last of slice would be latest version singe versions are asc order
+	return allVersions[len(allVersions)-1], nil
+}
+
+func ensurePluginExist(plugins Plugins, plugin string) {
+	if !plugins[plugin] {
+		fmt.Printf("Add plugin %s\n", plugin)
+		// ignore error if plugin is already installed.
+		// TODO: improve this check
+		_ = sh.RunV("asdf", "plugin", "add", plugin)
+	}
+}
+
+func installPackage(plugin string, version Version) error {
+	fmt.Printf("Installing plugin %s with version %s\n", plugin, version.Version)
+
+	err := sh.RunV("asdf", "install", plugin, version.Version)
+	if err != nil {
+		return fmt.Errorf("failed to install %s: %w", plugin, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adds `asdf` targets to `mage` to control runtime versions. These targets are a necessary intermediate step to migrate tasks not compatible with `mage`.

Targets( with asdf namespace):

```
› mage                                                     
Targets:
  asdf:install    installs all plugins and versions specified in local and global .tool-versions file
  asdf:upgrade    upgrades all plugins and versions specified in local .tool-versions file
```

Install:

```
› mage asdf:install
act 0.2.30 is already installed
age 1.1.0-rc.1 is already installed
...
sops 3.7.3 is already installed
yq 4.25.3 is already installed
```

Upgrade:
```
› mage asdf:upgrade
plugin awscli is already up to date with version 2.8.12
...
upgrading age from 1 to 1.1.0-rc.1
age 1.1.0-rc.1 is already installed
....
plugin pre-commit is frozen, with version 2.19.0, skipping upgrade
```

Install custom plugin from `mage` target:

```
func SomeTask(ctx context.Context) error {
	err := asdf.InstallPlugins("golang", "helm", "kubernetes-cli")
	if err != nil {
		return err
	}
	
	// Do something ...
	
	return nil
}
```