### PR TITLE
feat: Add github-cli dagger package

### DIFF
--- a/dagger/githubcli/dagger.go
+++ b/dagger/githubcli/dagger.go
@@ -1,0 +1,102 @@
+package githubcli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"dagger.io/dagger"
+
+	"github.com/mesosphere/daggers/dagger/options"
+)
+
+const (
+	// url template for downloading github cli from github releases.
+	ghURLTemplate = "https://github.com/cli/cli/releases/download/v%s/gh_%s_linux_amd64.tar.gz"
+
+	// standard source path.
+	srcDir = "/src"
+)
+
+// Run runs the ginkgo run command with given options.
+func Run(ctx context.Context, client *dagger.Client, workdir *dagger.Directory, opts ...Option) (string, error) {
+	cfg, err := loadConfigFromEnv()
+	if err != nil {
+		return "", err
+	}
+
+	for _, o := range opts {
+		cfg = o(cfg)
+	}
+
+	container, err := getGHContainer(ctx, client, workdir, &cfg)
+	if err != nil {
+		return "", err
+	}
+
+	container = container.
+		WithMountedDirectory(srcDir, workdir).
+		WithWorkdir(srcDir).
+		WithEnvVariable("CACHE_BUSTER", time.Now().String()). // Workaround for stop caching after this step
+		Exec(dagger.ContainerExecOpts{Args: cfg.Args})
+
+	output, err := container.Stdout().Contents(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(output), nil
+}
+
+// getGHContainer returns a dagger container instance with github cli as entrypoint.
+func getGHContainer(
+	ctx context.Context, client *dagger.Client, workdir *dagger.Directory, cfg *config,
+) (*dagger.Container, error) {
+	var err error
+
+	// Source url for downloading the Github CLI
+	srcURL := fmt.Sprintf(ghURLTemplate, cfg.GithubCliVersion, cfg.GithubCliVersion)
+
+	// Destination file to download tar file contains Github CLI
+	dstFile := "/tmp/gh_linux_amd64.tar.gz"
+
+	// Extract Directory
+	extractDir := "/tmp"
+
+	// Cli path after extracting downloaded tar to extract directory
+	cliPath := fmt.Sprintf("/tmp/gh_%s_linux_amd64/bin/gh", cfg.GithubCliVersion)
+
+	var customizers []options.ContainerCustomizer
+
+	customizers = append(customizers, options.WithMountedGoCache(ctx, workdir), options.DownloadFile(srcURL, dstFile))
+
+	container := client.Container().From(fmt.Sprintf("%s:%s", cfg.GoBaseImage, cfg.GoVersion))
+
+	for _, customizer := range customizers {
+		container, err = customizer(container, client)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	token := client.Host().EnvVariable("GITHUB_TOKEN").Secret()
+
+	container = container.
+		WithSecretVariable("GITHUB_TOKEN", token).
+		Exec(dagger.ContainerExecOpts{Args: []string{"tar", "-xf", dstFile, "-C", extractDir}}).
+		Exec(dagger.ContainerExecOpts{Args: []string{"mv", cliPath, "/usr/local/bin/gh"}}).
+		Exec(dagger.ContainerExecOpts{Args: []string{"rm", "-rf", "/tmp/*"}}).
+		WithEntrypoint([]string{"/usr/local/bin/gh"})
+
+	for _, extension := range cfg.Extensions {
+		container = container.Exec(dagger.ContainerExecOpts{Args: []string{"extension", "install", extension}})
+	}
+
+	_, err = container.ExitCode(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return container, nil
+}

--- a/dagger/githubcli/doc.go
+++ b/dagger/githubcli/doc.go
@@ -1,0 +1,2 @@
+// Package githubcli provides a command line interface to the GitHub CLI.
+package githubcli

--- a/dagger/githubcli/options.go
+++ b/dagger/githubcli/options.go
@@ -1,0 +1,66 @@
+package githubcli
+
+import (
+	"github.com/caarlos0/env/v6"
+)
+
+type config struct {
+	GoBaseImage      string   `env:"GO_BASE_IMAGE,notEmpty" envDefault:"docker.io/golang"`
+	GoVersion        string   `env:"GO_VERSION,notEmpty" envDefault:"1.19"`
+	GithubCliVersion string   `env:"VERSION,notEmpty" envDefault:"2.20.2"`
+	Extensions       []string `env:"EXTENSIONS" envDefault:""`
+	Args             []string `env:"ARGS" envDefault:""  envSeparator:" "`
+}
+
+func loadConfigFromEnv() (config, error) {
+	cfg := config{}
+
+	if err := env.Parse(&cfg, env.Options{Prefix: "GH_"}); err != nil {
+		return cfg, err
+	}
+
+	return cfg, nil
+}
+
+// Option is a function that configures the precommit checks.
+type Option func(config) config
+
+// WithGoBaseImage sets the go base image to use for the container.
+func WithGoBaseImage(image string) Option {
+	return func(c config) config {
+		c.GoBaseImage = image
+		return c
+	}
+}
+
+// WithGoVersion sets the go version to use for the container.
+func WithGoVersion(version string) Option {
+	return func(c config) config {
+		c.GoVersion = version
+		return c
+	}
+}
+
+// WithGithubCliVersion sets the github cli version to use for the container.
+func WithGithubCliVersion(version string) Option {
+	return func(c config) config {
+		c.GithubCliVersion = version
+		return c
+	}
+}
+
+// WithExtensions sets the extensions to install for github cli.
+func WithExtensions(extensions ...string) Option {
+	return func(c config) config {
+		c.Extensions = extensions
+		return c
+	}
+}
+
+// WithArgs sets the arguments to pass to github cli.
+func WithArgs(args ...string) Option {
+	return func(c config) config {
+		c.Args = args
+		return c
+	}
+}


### PR DESCRIPTION
Introduces github-cli as dagger package. The mage package was skipped because of the lack of a use case. 

Example usage: 

```go
	client, err := dagger.Connect(ctx, dagger.WithLogOutput(logger))
	if err != nil {
		return err
	}
	defer client.Close()

	out, err := githubcli.Run(
		ctx, client, client.Host().Workdir(),
		githubcli.WithGoVersion("1.17.1"),
		githubcli.WithGithubCliVersion("1.13.1"),
		githubcli.WithGoBaseImage("golang"),
		githubcli.WithExtensions("dlvhdr/gh-dash", "thatvegandev/gh-eco"),
		githubcli.WithArgs("dash"),
	)
	if err != nil {
		return err
	}

	fmt.Println(out)
```

Env config options:

- **GH_GO_BASE_IMAGE**, sets the base image for the container. Default `golang`
- **GH_GO_VERSION**, sets the image tag/version for the container. Default `1.19`
- **GH_VERSION**, sets the GitHub CLI version to use. Default `2.20.2`
- **GH_EXTENSIONS,** comma-separated list of extensions to install GitHub CLI.
- **GH_ARGS**, Args to pass to container execution. Required.
- **GITHUB_TOKEN,** Github PAT or CI Token to authenticate GitHub CLI. Required. 


Depends on #37 
