### PR TITLE
fix: list all plugin versions not just installed ones

### DIFF
--- a/catalog/asdf/asdf.go
+++ b/catalog/asdf/asdf.go
@@ -46,7 +46,7 @@ func ListPlugins() (Plugins, error) {
 
 // ListPluginVersions lists all installed versions of software for the specified plugin in ascending order.
 func ListPluginVersions(plugin string) ([]string, error) {
-	output, err := sh.Output("asdf", "list", plugin)
+	output, err := sh.Output("asdf", "list", "all", plugin)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Lists all plugin versions  instead of just installed versions

Depends on #57 