### PR TITLE
feat: load Github env vars in CustomizedContainerFromImage if CI is true

### DIFF
--- a/catalog/githubcli/dagger.go
+++ b/catalog/githubcli/dagger.go
@@ -56,7 +56,7 @@ func GetContainer(
 
 	customizers = append(customizers, cfg.ContainerCustomizers...)
 
-	container, err := containers.CustomizedContainerFromImage(runtime, image, cfg.MountWorkDir, customizers...)
+	container, err := containers.CustomizedContainerFromImage(ctx, runtime, image, cfg.MountWorkDir, customizers...)
 	if err != nil {
 		return nil, err
 	}

--- a/catalog/golang/dagger.go
+++ b/catalog/golang/dagger.go
@@ -52,7 +52,7 @@ func GetContainer(
 
 	customizers = append(customizers, cfg.ContainerCustomizers...)
 
-	container, err := containers.CustomizedContainerFromImage(runtime, image, true, customizers...)
+	container, err := containers.CustomizedContainerFromImage(ctx, runtime, image, true, customizers...)
 	if err != nil {
 		return nil, err
 	}

--- a/catalog/precommit/dagger.go
+++ b/catalog/precommit/dagger.go
@@ -43,7 +43,7 @@ func Run(ctx context.Context, runtime *daggers.Runtime, opts ...daggers.Option[c
 		containers.WithMountedCache(cacheVol, cacheDir, precommitHomeEnvVar),
 	)
 
-	container, err := containers.CustomizedContainerFromImage(runtime, cfg.BaseImage, true, customizers...)
+	container, err := containers.CustomizedContainerFromImage(ctx, runtime, cfg.BaseImage, true, customizers...)
 	if err != nil {
 		return "", err
 	}

--- a/catalog/svu/dagger.go
+++ b/catalog/svu/dagger.go
@@ -29,7 +29,7 @@ func Run(ctx context.Context, runtime *daggers.Runtime, options ...daggers.Optio
 		svuFlags = cfg.toArgs()
 	)
 
-	container, err := containers.CustomizedContainerFromImage(runtime, image, true)
+	container, err := containers.CustomizedContainerFromImage(ctx, runtime, image, true)
 	if err != nil {
 		return nil, err
 	}

--- a/daggers/runtime.go
+++ b/daggers/runtime.go
@@ -3,6 +3,7 @@ package daggers
 import (
 	"context"
 	"io"
+	"os"
 
 	"dagger.io/dagger"
 )
@@ -72,4 +73,14 @@ func (r *Runtime) Workdir() *dagger.Directory {
 // Close closes the dagger client.
 func (r *Runtime) Close() error {
 	return r.client.Close()
+}
+
+// IsCI returns true if the runtime is running in a CI environment. This check rely on CI environment variable set
+// by GitHub Actions. If the CI environment variable is not set, it returns false.
+//
+// https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+func (r *Runtime) IsCI() bool {
+	// Using os.Getenv instead client.Host().Env() because this check should be simple and with dagger client
+	// we would need context and error handling which is not needed here.
+	return os.Getenv("CI") == "true"
 }


### PR DESCRIPTION
Introduces container customizer to load GITHUB env vars and modifies CustomizedContainerFromImage to automatically load these vars,  if the CI flag is set to true.

Depends on #60 