### PR TITLE
feat: add default version option to asdf plugin versions

### DIFF
--- a/catalog/asdf/asdf.go
+++ b/catalog/asdf/asdf.go
@@ -117,3 +117,25 @@ func traverseNonCommentLines(r io.Reader, visit func(line string)) {
 		visit(line)
 	}
 }
+
+// GetVersionOrDefault returns the version of the plugin with given prefix if it exists in the map, otherwise returns
+// the default version.
+//
+// withPrefix is used to specify the prefix of the plugin version. For example, if the plugin version is 1.2.3, then
+// withPrefix is `v` and the returned version will be `v1.2.3`. If withPrefix is empty, then the returned version will
+// be `1.2.3`. This is useful when the plugin version is prefixed with a `v` and the plugin doesn't support it.
+//
+// WithPrefix only applies to the returned version, not applied the default version.
+func (p PluginVersions) GetVersionOrDefault(plugin, withPrefix, defaultVersion string) string {
+	version := defaultVersion
+
+	if v, ok := p[plugin]; ok {
+		if !strings.HasPrefix(v.Version, withPrefix) {
+			version = withPrefix + v.Version
+		} else {
+			version = v.Version
+		}
+	}
+
+	return version
+}

--- a/catalog/asdf/asdf_test.go
+++ b/catalog/asdf/asdf_test.go
@@ -27,3 +27,16 @@ foo
 
 	assert.Equal(t, count, 1)
 }
+
+func TestPluginVersions_GetVersionOrDefault(t *testing.T) {
+	versions := PluginVersions{
+		"foo": {
+			Version:       "1.2.3",
+			VersionFreeze: true,
+		},
+	}
+
+	assert.Equal(t, versions.GetVersionOrDefault("foo", "v", "latest"), "v1.2.3")
+	assert.Equal(t, versions.GetVersionOrDefault("foo", "", "latest"), "1.2.3")
+	assert.Equal(t, versions.GetVersionOrDefault("bar", "v", "1.0.0"), "1.0.0")
+}


### PR DESCRIPTION
Adds 'GetVersionOrDefault` to return a default version of the tool if it's missing in `.tool_versions`