### PR TITLE
fix: do not add empty args to container

### DIFF
--- a/catalog/golang/dagger.go
+++ b/catalog/golang/dagger.go
@@ -57,5 +57,11 @@ func GetContainer(
 		return nil, err
 	}
 
-	return container.WithEntrypoint([]string{"go"}).WithExec(cfg.Args), nil
+	container = container.WithEntrypoint([]string{"go"})
+
+	if len(cfg.Args) > 0 {
+		container = container.WithExec(cfg.Args)
+	}
+
+	return container, nil
 }


### PR DESCRIPTION
We shouldn't call `WithExec` without any arguments. Otherwise, the dagger automatically as `bash` as arg and causes unexpected failures 