### PR TITLE
refactor: except external directories as workdir as well

### DIFF
--- a/daggers/runtime.go
+++ b/daggers/runtime.go
@@ -27,16 +27,15 @@ func NewRuntime(ctx context.Context, opts ...Option[runtimeConfig]) (*Runtime, e
 
 	return &Runtime{
 		client:  client,
-		workdir: client.Host().Directory(rc.workdir, rc.workdirOpts),
+		workdir: rc.workdirFn(client),
 	}, nil
 }
 
 // getRuntimeConfig initializes a runtime config with default values and applies given options before returning it.
 func getRuntimeConfig(opts []Option[runtimeConfig]) runtimeConfig {
 	rc := runtimeConfig{
-		verbose:     false,
-		workdir:     ".",
-		workdirOpts: dagger.HostDirectoryOpts{},
+		verbose:   false,
+		workdirFn: func(client *dagger.Client) *dagger.Directory { return client.Host().Directory(".") },
 	}
 
 	for _, o := range opts {

--- a/daggers/runtime_options.go
+++ b/daggers/runtime_options.go
@@ -5,9 +5,8 @@ import (
 )
 
 type runtimeConfig struct {
-	verbose     bool
-	workdir     string
-	workdirOpts dagger.HostDirectoryOpts
+	verbose   bool
+	workdirFn func(client *dagger.Client) *dagger.Directory
 }
 
 // WithVerbose sets the verbose option for the runtime config.
@@ -18,18 +17,22 @@ func WithVerbose(verbose bool) Option[runtimeConfig] {
 	}
 }
 
-// WithWorkdir sets the workdir option for the runtime config.
-func WithWorkdir(workdir string) Option[runtimeConfig] {
+// WithWorkdir sets the workdir options for the runtime config.
+func WithWorkdir(workdir *dagger.Directory) Option[runtimeConfig] {
 	return func(rc runtimeConfig) runtimeConfig {
-		rc.workdir = workdir
+		rc.workdirFn = func(client *dagger.Client) *dagger.Directory {
+			return workdir
+		}
 		return rc
 	}
 }
 
-// WithWorkdirOpts sets the workdir options for the runtime config.
-func WithWorkdirOpts(workdirOpts dagger.HostDirectoryOpts) Option[runtimeConfig] {
+// WithWorkdirFromHostPath sets the workdir option from host path for the runtime config.
+func WithWorkdirFromHostPath(workdir string, opts ...dagger.HostDirectoryOpts) Option[runtimeConfig] {
 	return func(rc runtimeConfig) runtimeConfig {
-		rc.workdirOpts = workdirOpts
+		rc.workdirFn = func(client *dagger.Client) *dagger.Directory {
+			return client.Host().Directory(workdir, opts...)
+		}
 		return rc
 	}
 }


### PR DESCRIPTION
This change allows us to give workdir directories like git repositories to runtime